### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update; fi
   - if [ $CC == clang ] && [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install -y llvm-3.4 llvm-3.4-dev; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install emacs build-essential texlive texinfo imagemagick gcc-multilib libc6-i386 libc6-dev-i386 g++-multilib; fi
-  - FTCLP_INSTALL=$TRAVIS_BUILD_DIR/ftclp
   - # CIAOTGZ=CiaoDE-latest.tar.gz; wget http://ciao-lang.org/packages/master/$CIAOTGZ; mkdir $CIAODIR; tar --directory "$CIAODIR" --strip-components=1 -xvzf "$TRAVIS_BUILD_DIR/$CIAOTGZ"
 
 before_script:
@@ -36,7 +35,7 @@ notifications:
   email: false
 
 env:
-  - LANG="en_US.UTF-8"
+  - LANG="en_US.UTF-8" FTCLP_INSTALL=$TRAVIS_BUILD_DIR/ftclp
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ notifications:
   email: false
 
 env:
-  - LANG="en_US.UTF-8" FTCLP_INSTALL=$TRAVIS_BUILD_DIR/ftclp
+  - LANG="en_US.UTF-8" FTCLP_INSTALL=$TRAVIS_BUILD_DIR
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: cpp
+
+compiler:
+  - gcc
+
+before_install:
+  - echo $LANG
+  - echo $LC_ALL
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update; fi
+  - if [ $CC == clang ] && [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install -y llvm-3.4 llvm-3.4-dev; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install emacs build-essential texlive texinfo imagemagick gcc-multilib libc6-i386 libc6-dev-i386 g++-multilib; fi
+  - FTCLP_INSTALL=$TRAVIS_BUILD_DIR/ftclp
+  - # CIAOTGZ=CiaoDE-latest.tar.gz; wget http://ciao-lang.org/packages/master/$CIAOTGZ; mkdir $CIAODIR; tar --directory "$CIAODIR" --strip-components=1 -xvzf "$TRAVIS_BUILD_DIR/$CIAOTGZ"
+
+before_script:
+  - # cd $CIAODIR; ./ciaosetup configure --instype=local --cc=$CC
+
+script:
+  - # cd $CIAODIR; ./ciaosetup build
+  - # cd $CIAODIR; ./ciaosetup install
+  - # cd $TRAVIS_BUILD_DIR
+  - # . $CIAODIR/ciao/etc/DOTprofile
+  - # ciaoc hw.pl
+  - # ./hw
+  - make install # TODO: This should be 'make install-deps'
+  - make all
+
+after_success:
+  - if [ $TRAVIS_BRANCH == $TRAVIS_TAG ]; then echo "missing deploy"; fi
+
+branches:
+  only:
+    - master
+
+notifications:
+  email: false
+
+env:
+  - LANG="en_US.UTF-8"
+
+os:
+  - linux
+

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ all:
 	@echo " ---------------------------------------------------------------"
 	@echo "   Compiling and generating executable                          "
 	@echo " ---------------------------------------------------------------"
+	mkdir -p $$FTCLP_INSTALL/bin
+	mkdir -p $$FTCLP_INSTALL/lib
 	ln -sf ${MSAT_DIR}/lib/libmathsat.a $$FTCLP_INSTALL/lib
 	cd solver && make 
 	cd trie && make

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/jfmc/ftclp.svg?branch=master)](https://travis-ci.org/jfmc/ftclp)
+
 # FTCLP
 
 Interpreter for Constraint Logic Programming (CLP), called FTCLP 

--- a/install_gmp
+++ b/install_gmp
@@ -51,6 +51,7 @@ if [[ ! -d "$GMP_INSTALL" ]]; then
     ABI=32 ./configure --prefix="$GMP_INSTALL/build" --enable-cxx
     make -C "$GMP_INSTALL"
     make install -C "$GMP_INSTALL"
+    mkdir -p "$SCRIPT_DIR/lib"
     ln -s "$GMP_INSTALL/build/lib/libgmp.a"  "$SCRIPT_DIR/lib/libgmp.a"
     ln -s "$GMP_INSTALL/build/lib/libgmpxx.a"  "$SCRIPT_DIR/lib/libgmpxx.a"
     echo -e "Installation finished successfully\n"


### PR DESCRIPTION
This adds a Travis CI config for continuous integration (which is free for open source projects). The scripts are still based on an old Ciao version (1.14). The config does not include builds on Mac OS X since builds for 32-bits are not provided and Ciao 1.14 cannot compile in 64-bits mode.

Note that README.md contains a build badge pointing to my 'jfmc' user. I am not sure how this can be fixed...
